### PR TITLE
Fixed typos

### DIFF
--- a/content/concurrency.article
+++ b/content/concurrency.article
@@ -160,8 +160,8 @@ Dans cet exercice, vous allez utiliser les fonctionnalités de simultanéité de
 
 Modifier la fonction `Crawl` pour ramener des URLs en parallèle sans aller chercher deux fois la même URL.
 
-*Note*:* vous pouvez garder un cache des URL qui ont été récupérés avec une carte, mais les cartes seuls ne sont pas
-sûr pour une utilisation simultanée!
+*Note*:* vous pouvez garder un cache des URL qui ont été récupérées avec une carte, mais les cartes seules ne sont pas
+sûres pour une utilisation simultanée !
 
 .play concurrency/exercise-web-crawler.go
 

--- a/static/js/values.js
+++ b/static/js/values.js
@@ -25,7 +25,7 @@ value('tableOfContents', [{
 }, {
     'id': 'concurrency',
     'title': 'Concurrency',
-    'description': '<p>Go offre des primitives de simultanéité dans le cadre du langage de base.<p></p>Ce module les présentent et donne quelques exemples sur la façon de les utilisés pour mettre en œuvre différents modèles de concurrence.</p>',
+    'description': '<p>Go offre des primitives de simultanéité dans le cadre du langage de base.<p></p>Ce module les présente et donne quelques exemples sur la façon de les utiliser pour mettre en œuvre différents modèles de concurrence.</p>',
     'lessons': ['concurrency']
 }]).
 


### PR DESCRIPTION
Fixed two typos in the description (French version) of the concurrency module.